### PR TITLE
Fixes typo in verilog model so it matches the schematics

### DIFF
--- a/Konami/053251/053251.v
+++ b/Konami/053251/053251.v
@@ -35,7 +35,7 @@ module k053251(
 
     input [1:0] SDI,
     output reg [1:0] SDO,
-    
+
     output reg [10:0] CO,
     output reg BRIT,
     output reg NCOL
@@ -129,7 +129,7 @@ wire J122A = (PR0PR1PR2PR3PR4MIX < ~REG5);
 wire SELSHA = (PR0PR1PR2PR3PR4MIX < PRSHA);
 
 // No need for L0 signal
-wire L1 = ~(SEL_W2 & REG11[5]) & ~(~SEL_L1 & REG11[5]);
+wire L1 = ~(SEL_W2 & REG11[5]) & ~(~SEL_L1 & ~REG11[5]);
 
 wire [5:0] PR0MUX = TRANSP0 ? (REG12[0] ? REG0 : PR0_Q) : 6'h3F;  // To check: gating
 wire [5:0] PR1MUX = TRANSP1 ? (REG12[1] ? REG1 : PR1_Q) : 6'h3F;  // To check: gating
@@ -180,37 +180,37 @@ always @(posedge CLK) begin
     PR0_Q <= PR0;
     PR1_Q <= PR1;
     PR2_Q <= PR2;
-    
+
     TRANSP0_W1 <= TRANSP0;
     TRANSP1_W1 <= TRANSP1;
     TRANSP2_W1 <= TRANSP2;
     TRANSP4_W1 <= TRANSP4;
-    
+
     L0L1L2MIX_Q <= L0L1L2MIX;
     T0T1T2MIX_Q <= T0T1T2MIX;
-    
+
     L0L1L2L3MIX_Q <= L0L1L2L3MIX;
     T0T1T2T3MIX_Q <= T0T1T2T3MIX;
-    
+
     CO <= L0L1L2L3L4MIX;
     NCOL <= T0T1T2T3T4MIX;
-    
+
     PR2_W1 <= PR2MUX;
     PR4_W1 <= PR4;
-    
+
     SEL_W1 <= SEL;
     SEL_W2 <= SEL_W1;
-    
+
     PR0MUX_Q <= PR0MUX;
     PR1MUX_Q <= PR1MUX;
-    
+
     PR0PR1PR2MIX_Q <= PR0PR1PR2MIX;
     PR0PR1PR2PR3MIX_Q <= PR0PR1PR2PR3MIX;
-    
+
     SEL_L1 <= A49;
     SEL_L4 <= G93;
     BRIT <= J122A;
-    
+
     SDI_Q <= SDI;
     SDI_W1 <= SDI_Q;
     SDI_W2 <= SDI_W1;


### PR DESCRIPTION
This typo fix will make the L1 signal match the schematic:

![imagen](https://github.com/furrtek/SiliconRE/assets/1863036/98b6cd7b-d398-4073-ad06-9f2e2436ed64)

The inverted REG11[5] is used in the upper NAND gate